### PR TITLE
Add TLS support via a `tls` feature

### DIFF
--- a/spicedb-client/Cargo.toml
+++ b/spicedb-client/Cargo.toml
@@ -25,3 +25,4 @@ tokio = { workspace = true, features = ["full"] }
 default = []
 
 futures = ["dep:futures"]
+tls = ["tonic/tls-webpki-roots"]

--- a/spicedb-client/src/client.rs
+++ b/spicedb-client/src/client.rs
@@ -6,7 +6,7 @@ use spicedb_grpc::authzed::api::v1::{
 use tonic::{
     metadata::{Ascii, MetadataValue},
     service::{interceptor::InterceptedService, Interceptor},
-    transport::Channel,
+    transport::{Channel, Endpoint},
     Request, Status, Streaming,
 };
 
@@ -42,7 +42,7 @@ impl SpicedbClient {
             preshared_key: Box::new(format!("bearer {}", preshared_key.to_string()).parse()?),
         };
 
-        let channel = Channel::from_shared(url)?.connect().await?;
+        let channel = Endpoint::new(url.into())?.connect().await?;
 
         let schemas = SchemaServiceClient::with_interceptor(channel.clone(), interceptor.clone());
 


### PR DESCRIPTION
This change adds optional support for HTTPS (i.e. TLS) SpiceDB endpoints. It's offered via a Cargo feature flag of `tls` which is not enabled by default. The change uses `Endpoint::new()` rather than `Channel::from_shared()` as the former has protocol detection already built in (that is, it contains a check looking for `https://`-leading URLs).

Thanks again for your hard work here!